### PR TITLE
Memory cleanup to make valgrind happier

### DIFF
--- a/include/MarlinTrk/Factory.h
+++ b/include/MarlinTrk/Factory.h
@@ -29,7 +29,9 @@ namespace MarlinTrk{
     
   public:
     
-    virtual ~Factory() {}
+    virtual ~Factory() {
+      for( auto& trkSystem : _map ) { delete trkSystem.second; }
+    }
     
     /** Create the MarlinTrkSystem instance of the specified type:<br>
      *  DDKalTest, aidaTT,...<br>

--- a/include/MarlinTrk/MarlinDDKalTest.h
+++ b/include/MarlinTrk/MarlinDDKalTest.h
@@ -7,6 +7,8 @@
 #include "MarlinTrk/DiagnosticsController.h"
 #endif
 
+#include "DDKalTest/DDKalDetector.h"
+
 //LCIO:
 #include "lcio.h"
 #include "UTIL/BitField64.h" 
@@ -105,7 +107,8 @@ namespace MarlinTrk{
     std::multimap< int,const DDVMeasLayer *> _active_measurement_modules;
     
     std::multimap< int,const DDVMeasLayer *> _active_measurement_modules_by_layer;
-    
+
+    std::vector< DDKalDetector* > _detectors{};
     
 #ifdef MARLINTRK_DIAGNOSTICS_ON
 

--- a/src/MarlinDDKalTest.cc
+++ b/src/MarlinDDKalTest.cc
@@ -53,7 +53,7 @@ namespace MarlinTrk{
 #ifdef MARLINTRK_DIAGNOSTICS_ON
     _diagnostics.end();
 #endif
-    
+    for( auto* ddKalDet : _detectors ) { delete ddKalDet; }
     delete _det ;
   }
   
@@ -116,7 +116,8 @@ namespace MarlinTrk{
 
       streamlog_out( DEBUG5 ) << "  MarlinDDKalTest::init() - creating DDKalDetector for : " << det.name() << std::endl ;
 
-      DDKalDetector* kalDet = new DDKalDetector( det ) ;
+      _detectors.push_back( new DDKalDetector( det ) );
+      DDKalDetector* kalDet = _detectors.back();
 
       this->storeActiveMeasurementModuleIDs( kalDet ) ;
 


### PR DESCRIPTION
Ideally the interfaces should be changed to return shared_ptrs to trkSystems, which would make the ownership obvious.

BEGINRELEASENOTES
- Clean up of tkrSystem and DDKalDetectors at the end of lifetime

ENDRELEASENOTES