### PR TITLE
Fix trkcfg

### DIFF
--- a/include/MarlinTrk/IMarlinTrkSystem.h
+++ b/include/MarlinTrk/IMarlinTrkSystem.h
@@ -119,5 +119,9 @@ namespace MarlinTrk {
   
 } // end of MarlinTrk namespace 
 
+
+#include "TrkSysConfig.h"
+
+
 #endif
 

--- a/include/MarlinTrk/TrkSysConfig.h
+++ b/include/MarlinTrk/TrkSysConfig.h
@@ -1,0 +1,45 @@
+#ifndef TrkSysConfig_h
+#define TrkSysConfig_h
+
+//#include "IMarlinTrkSystem.h"
+
+
+
+namespace MarlinTrk{
+
+  class IMarlinTrkSystem ;
+
+  /** Helper class for temporarilly setting a configuration option of the tracking system for
+   *  the current scope. The old seeting will be restored, when the class
+   *  gets out of scope.  
+   *
+   * @author F. Gaede DESY
+   * @date 10/2017
+   */
+
+
+  template <unsigned CFG>
+  class TrkSysConfig{
+    
+  public:
+    
+    TrkSysConfig() = delete ;
+    
+    TrkSysConfig(IMarlinTrkSystem* trksys, bool value) : _trksys( trksys ){
+
+      _value = _trksys->getOption(CFG) ;
+      _trksys->setOption(CFG,value) ;
+    }
+
+    ~TrkSysConfig(){
+      _trksys->setOption(CFG,_value) ;
+    }
+
+  protected:
+    IMarlinTrkSystem* _trksys = 0;    
+    bool _value = false ;
+  } ;
+ 
+
+}
+#endif

--- a/src/MarlinDDKalTestTrack.cc
+++ b/src/MarlinDDKalTestTrack.cc
@@ -288,7 +288,7 @@ namespace MarlinTrk {
     Cov(1,1) = 1.e2 ; // dphi0
     Cov(2,2) = 1.e1 ; // dkappa
     Cov(3,3) = 1.e6 ; // dz
-    Cov(4,4) = 1.e2 ; // dtanL
+    Cov(4,4) = 1.e1 ; // dtanL
     if (kSdim == 6) Cov(5,5) = 1.e2;  // t0
           
     // Add initial states to the site 


### PR DESCRIPTION

BEGINRELEASENOTES
- add new helper class TrkSysConfig for setting the correct system configuration per event (scope)
- reduce initial error on tanLambda in `MarlinDDKalTestTrack::initialise()`

ENDRELEASENOTES