### PR TITLE
Adopt for cleaning of DD4hep

### DIFF
--- a/include/MarlinTrk/IMarlinTrack.h
+++ b/include/MarlinTrk/IMarlinTrack.h
@@ -8,7 +8,7 @@
 #include "EVENT/TrackerHit.h"
 #include "IMPL/TrackStateImpl.h"
 
-#include "DDSurfaces/Vector3D.h"
+#include "DDRec/Vector3D.h"
 
 #include <exception>
 #include <string>
@@ -23,7 +23,7 @@
 namespace MarlinTrk{
   
   /// the Vector3D used for the tracking interface
-  typedef DDSurfaces::Vector3D Vector3D ;
+  typedef dd4hep::rec::Vector3D Vector3D ;
   
   /** Interface for generic tracks in MarlinTrk. The interface should provide the functionality to
    *  perform track finding and fitting. It is asssumed that the underlying implemetation will by 


### PR DESCRIPTION
needed for AIDASoft/DD4hep#345
BEGINRELEASENOTES
- Fix for the removal of DDSurfaces which have been merged into DDRec 
  -  includes from `DDSurfaces` -> `DDRec`
  - namespace `DDSurfaces` -> `dd4hep::rec`

ENDRELEASENOTES