### PR TITLE
Fix memory leak inside MarlinDDKalTest::createTrack()

### DIFF
--- a/include/MarlinTrk/MarlinDDKalTest.h
+++ b/include/MarlinTrk/MarlinDDKalTest.h
@@ -2,6 +2,7 @@
 #define MarlinDDKalTest_h
 
 #include "MarlinTrk/IMarlinTrkSystem.h"
+#include "MarlinTrk/MarlinDDKalTestTrack.h"
 
 #ifdef MARLINTRK_DIAGNOSTICS_ON
 #include "MarlinTrk/DiagnosticsController.h"
@@ -112,6 +113,8 @@ namespace MarlinTrk{
     
     TKalDetCradle* _det=nullptr;         // the detector cradle
     
+    MarlinDDKalTestTrack* _marlinTrack = nullptr;
+
     std::multimap< int,const DDVMeasLayer *> _active_measurement_modules{};
     
     std::multimap< int,const DDVMeasLayer *> _active_measurement_modules_by_layer{};

--- a/src/MarlinDDKalTest.cc
+++ b/src/MarlinDDKalTest.cc
@@ -1,5 +1,4 @@
 #include "MarlinTrk/MarlinDDKalTest.h"
-#include "MarlinTrk/MarlinDDKalTestTrack.h"
 
 #include "kaltest/TKalDetCradle.h"
 #include "kaltest/TVKalDetector.h"
@@ -55,6 +54,7 @@ namespace MarlinTrk{
 #endif
     for( auto* ddKalDet : _detectors ) { delete ddKalDet; }
     delete _det ;
+    delete _marlinTrack;
   }
   
   
@@ -226,8 +226,8 @@ namespace MarlinTrk{
       throw MarlinTrk::Exception(errorMsg.str());
       
     }
-    
-    return new MarlinDDKalTestTrack(this) ;
+    _marlinTrack = new MarlinDDKalTestTrack(this);
+    return _marlinTrack ;
     
   }
   


### PR DESCRIPTION

BEGINRELEASENOTES
- Fixed memory leak inside MarlinDDKalTest::createTrack()
ENDRELEASENOTES

Addressing #19.

I am not sure, but wouldn't it be enough for the time being?