### PR TITLE
Fix bug of the trackState at the barrel instead of the ECal

### DIFF
--- a/src/MarlinTrkUtils.cc
+++ b/src/MarlinTrkUtils.cc
@@ -842,13 +842,13 @@ namespace MarlinTrk {
     // check which is the right intersection / closer to the trkhit
     if ( return_error_barrel == IMarlinTrack::no_intersection ){
         //if barrel fails just return ts at the Endcap if exists
-        return_error = marlintrk->propagateToLayer(encoder.lowWord(), trkhit, *trkStateCalo, chi2, ndf, detElementID, IMarlinTrack::modeForward );
+        return_error = return_error_endcap;
+        *trkStateCalo = tsEndcap;
     }
     else if( return_error_endcap == IMarlinTrack::no_intersection ){
         //if barrel succeeded and endcap fails return ts at the barrel
-        encoder[lcio::LCTrackerCellID::subdet()] = ecal_barrel_face_ID ;
-        encoder[lcio::LCTrackerCellID::side()]   = lcio::ILDDetID::barrel;
-        return_error = marlintrk->propagateToLayer(encoder.lowWord(), trkhit, *trkStateCalo, chi2, ndf, detElementID, IMarlinTrack::modeForward ) ;
+        return_error = return_error_barrel;
+        *trkStateCalo = tsBarrel;
     }
     else{
         //this means both barrel and endcap have intersections. Return closest to the tracker hit
@@ -858,12 +858,12 @@ namespace MarlinTrk {
         double dToBarrel = (hitPos-barrelPos).r();
         double dToendcap = (hitPos-endcapPos).r();
         if ( dToBarrel < dToendcap ){
-            encoder[lcio::LCTrackerCellID::subdet()] = ecal_barrel_face_ID ;
-            encoder[lcio::LCTrackerCellID::side()]   = lcio::ILDDetID::barrel;
-            return_error = marlintrk->propagateToLayer(encoder.lowWord(), trkhit, *trkStateCalo, chi2, ndf, detElementID, IMarlinTrack::modeForward ) ;
+            return_error = return_error_barrel;
+            *trkStateCalo = tsBarrel;
         }
         else{
-            return_error = marlintrk->propagateToLayer(encoder.lowWord(), trkhit, *trkStateCalo, chi2, ndf, detElementID, IMarlinTrack::modeForward );
+            return_error = return_error_endcap;
+            *trkStateCalo = tsEndcap;
         }   
     }
     

--- a/src/MarlinTrkUtils.cc
+++ b/src/MarlinTrkUtils.cc
@@ -98,7 +98,7 @@ namespace MarlinTrk {
   
   
   
-  // int createTrackStateAtCaloFace( IMarlinTrack* marlinTrk, IMPL::TrackStateImpl* track, EVENT::TrackerHit* trkhit, bool tanL_is_positive );
+  int createTrackStateAtCaloFace( IMarlinTrack* marlinTrk, IMPL::TrackStateImpl* track, EVENT::TrackerHit* trkhit, bool tanL_is_positive );
   
   int createFinalisedLCIOTrack( IMarlinTrack* marlinTrk, std::vector<EVENT::TrackerHit*>& hit_list, IMPL::TrackImpl* track, bool fit_direction, const EVENT::FloatVec& initial_cov_for_prefit, float bfield_z, double maxChi2Increment){
     


### PR DESCRIPTION
BEGINRELEASENOTES

- Now checking for the intersection with the endcaps even if intersection with the barrel has been found. The closest track state to the last tracker hit is saved

ENDRELEASENOTES

This fixes #20 .

<img src="https://user-images.githubusercontent.com/28848011/134850136-443b6277-eb11-434e-aedc-c65864845a4a.png" width="600px;"/>

Small cross check shows that tracks with the distance between trackStateAtEcal and closest Ecal hit > 5 m vanish.
And pfo by pfo difference is 0 for all the other tracks, which means they are unaffected.


<img src="https://user-images.githubusercontent.com/28848011/134849927-9b77988a-727f-46ac-9674-55d8f89acb63.png" width="400px;"/> <img src="https://user-images.githubusercontent.com/28848011/134850086-052dff72-075b-4694-8031-8f01ce3ab4cf.png" width="400px;"/>


Code feels very clumsy and probably can be improved...
@gaede , @tmadlener will be happy for any thoughts, comments, suggestions..