### PR TITLE
Fix doxygen cmake config for newer cmake versions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " ..
+          cmake -GNinja -C ${ILCSOFT}/ILCSoft.cmake -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DINSTALL_DOC=ON ..
           ninja -k0
           ctest --output-on-failure
           ninja install

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,6 +15,7 @@ IF( DOXYGEN_FOUND )
     # directories to search for documentation
     SET( DOX_INPUT ../include ../src )
 
+    FILE(GLOB DOXYGEN_SOURCES ../include/* ../src/*)
 
     # custom command to build documentation
     ADD_CUSTOM_COMMAND(
@@ -26,7 +27,7 @@ IF( DOXYGEN_FOUND )
                 "${DOXYGEN_EXECUTABLE}"
         WORKING_DIRECTORY "${DOC_SRC_DIR}"
         COMMENT "Building API Documentation..."
-        DEPENDS Doxyfile CMakeLists.txt ../include/* ../src/*
+        DEPENDS Doxyfile CMakeLists.txt ${DOXYGEN_SOURCES}
     )
 
     # add doc target


### PR DESCRIPTION

BEGINRELEASENOTES
- Fix doxygen cmake config to also work with newer cmake versions (>= 3.17)

ENDRELEASENOTES